### PR TITLE
Fix missing session argument in example

### DIFF
--- a/R/exec.R
+++ b/R/exec.R
@@ -22,7 +22,7 @@
 #' @param std_err callback function, filename, or connection object to handle stderr stream
 #' @examples \dontrun{
 #' session <- ssh_connect("dev.opencpu.org")
-#' ssh_exec_wait(command = c(
+#' ssh_exec_wait(session, command = c(
 #'   'curl -O https://cran.r-project.org/src/contrib/jsonlite_1.5.tar.gz',
 #'   'R CMD check jsonlite_1.5.tar.gz',
 #'   'rm -f jsonlite_1.5.tar.gz'


### PR DESCRIPTION
Hi 

Thanks for this super cool package. Have used it quite a bit already and it has helped me streamline my workflow a lot. So thanks!

This PR is just one tiny change that insert the session argument into the example of ssh_exec_wait().